### PR TITLE
Fix for path of JavaScript in 1.x Semantic-UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <requirejs>
             {
                 "paths": {
-                    "Semantic-UI": "packaged/javascript/semantic"
+                    "Semantic-UI": "semantic"
                 },
                 "shim": {
                     "Semantic-UI": ["jquery"]


### PR DESCRIPTION
The requirejs stub was pointing to an invalid location, leading to the JavaScript file of Semantic UI being unable to be found via requirejs inclusion.
Regards, Christian